### PR TITLE
Move pinMode initialization (outside of constructor)

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Queuetue HX711 Library
-version=1.0.1
+version=1.0.2
 author=Scott Russell <scott@queuetue.com>
 maintainer=Scott Russell <scott@queuetue.com>
 sentence=Simple driver for the HX711 ADC.

--- a/src/Q2HX711.cpp
+++ b/src/Q2HX711.cpp
@@ -5,14 +5,19 @@ Q2HX711::Q2HX711(byte output_pin, byte clock_pin) {
   CLOCK_PIN  = clock_pin;
   OUT_PIN  = output_pin;
   GAIN = 1;
-  pinMode(CLOCK_PIN, OUTPUT);
-  pinMode(OUT_PIN, INPUT);
+  pinsConfigured = false;
 }
 
 Q2HX711::~Q2HX711() {
 }
 
 bool Q2HX711::readyToSend() {
+  if (!pinsConfigured) {
+    // We need to set the pin mode once, but not in the constructor
+    pinMode(CLOCK_PIN, OUTPUT);
+    pinMode(OUT_PIN, INPUT);
+    pinsConfigured = true;
+  }
   return digitalRead(OUT_PIN) == LOW;
 }
 

--- a/src/Q2HX711.h
+++ b/src/Q2HX711.h
@@ -8,11 +8,13 @@ class Q2HX711
     byte CLOCK_PIN;
     byte OUT_PIN;
     byte GAIN;
-    void setGain(byte gain = 128);
+    bool pinsConfigured;
+
   public:
     Q2HX711(byte output_pin, byte clock_pin);
     virtual ~Q2HX711();
     bool readyToSend();
+    void setGain(byte gain = 128);
     long read();
 };
 


### PR DESCRIPTION
> previously, the pinMode was being set in the constructor, which wouldn't take effect (e.g. on MKR1000), and communication with the HX711 would fail (when the Q2HX711 object was declared as a global, as in the simple_scale example).

See https://github.com/arduino/ArduinoCore-samd/issues/169 for discussion related to this (problem I discovered when using Q2HX711 and switching from v1.6.6 to v1.6.7 of the SAMD tools used with the Arduino MKR1000.  My first direction of investigation was off-track; it turned out it was because the pinMode wasn't set properly (the clock wasn't being taken as OUTPUT) when using the Q2HX711, since these calls were made in the Q2HX711 constructor.  The solution could be:
- something like I've done in this PR to minimize changes for existing code (being sure to call pinMode() once, but outside of the constructor)
- or, simply to insist that people not use global objects, but rather allocate the Q2HX711 object in setup(), and reference it by pointer
- or...add a `setPinMode()` method that must be explicitly called by the user in their `setup()`, which would configure the pins.
