### PR TITLE
Add two new functions; powerDown() and powerUp().

### DIFF
--- a/src/Q2HX711.cpp
+++ b/src/Q2HX711.cpp
@@ -12,6 +12,25 @@ Q2HX711::Q2HX711(byte output_pin, byte clock_pin) {
 Q2HX711::~Q2HX711() {
 }
 
+/**
+ * Puts the chip in power down mode by setting the clock signal high.
+ *
+ * The HX711 will enter power down when PD_SCK is high for more then 60μs.
+ */
+void Q2HX711::powerDown() {
+    digitalWrite(CLOCK_PIN, HIGH);
+}
+
+/**
+ * Wakes the chip from power down mode by setting the clock signal low.
+ *
+ * When PD_SCK returns to low, the HX711 will reset and enter normal operation mode.
+ * After a reset or power-down event, input selection is default to Channel A with a gain of 128.
+ */
+void Q2HX711::powerUp() {
+    digitalWrite(CLOCK_PIN, LOW);
+}
+
 bool Q2HX711::readyToSend() {
   return digitalRead(OUT_PIN) == LOW;
 }
@@ -29,7 +48,7 @@ void Q2HX711::setGain(byte gain) {
       break;
   }
 
-  digitalWrite(CLOCK_PIN, LOW);
+  powerUp();
   read();
 }
 

--- a/src/Q2HX711.h
+++ b/src/Q2HX711.h
@@ -9,9 +9,12 @@ class Q2HX711
     byte OUT_PIN;
     byte GAIN;
     void setGain(byte gain = 128);
+
   public:
     Q2HX711(byte output_pin, byte clock_pin);
     virtual ~Q2HX711();
+    void powerDown();
+    void powerUp();
     bool readyToSend();
     long read();
 };


### PR DESCRIPTION
Hi Scott.

Thanks for providing you library under the MIT license.
I am adding a little funtionality to the library - hope you like it.

Best regards,
  Søren Thing

The HX711 will enter power down when PD_SCK is high for more then 60μs.
On my demo board powerDown() lowers the current consumption from ~15mA to less than 0.01mA.