### PR TITLE
Update Q2HX711.h

### DIFF
--- a/src/Q2HX711.h
+++ b/src/Q2HX711.h
@@ -16,6 +16,6 @@ class Q2HX711
     bool readyToSend();
     void setGain(byte gain = 128);
     long read();
-};
+} // Semicolon removed due to the error :: multiple types in one declaration
 
 #endif /* Q2HX711_h */


### PR DESCRIPTION
By removing the semicolon after the Right Curly Bracket as the end of class definition which causes the error: "multiple types in one declaration", All things will be all right.